### PR TITLE
Added API endpoints to download the data release files

### DIFF
--- a/htdocs/api/v0.0.3-dev/.htaccess
+++ b/htdocs/api/v0.0.3-dev/.htaccess
@@ -16,6 +16,8 @@ RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/instruments(/*)$ projects/Project.php
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/images(/*)$ projects/Images.php?project_name=$1 [QSA,L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/bids(/*)$ projects/Bids.php?project_name=$1&PrintFiles=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/bids/([a-zA-Z0-9_.\-]+)$ projects/bids/BidsFile.php?project_name=$1&Filename=$2&PrintFileData=true [L]
+RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/data_releases(/*)$ projects/DataReleases.php?project_name=$1&PrintFiles=true [L]
+RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/data_releases/([a-zA-Z0-9_.\-]+)$ projects/datareleases/DataReleaseFile.php?project_name=$1&Filename=$2&PrintFileData=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)(/*)$ projects/Project.php?Project=$1&Instruments=true&Visits=true&Candidates=true&PrintProjectJSON=true [L]
 
 RewriteRule ^projects(/*)$ Projects.php?PrintProjects=true [L]
@@ -52,3 +54,5 @@ RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.-]+)/bids/
 ## DICOMs API related URLs
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/dicoms$ candidates/visits/Dicoms.php?CandID=$1&VisitLabel=$2&PrintDicoms=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/dicoms/([a-zA-Z0-9_.-]+)$ candidates/visits/dicoms/Dicom.php?CandID=$1&VisitLabel=$2&Tarname=$3&PrintDicomData=true [L]
+
+## Data Releases API related URLs

--- a/htdocs/api/v0.0.3-dev/projects/DataReleases.php
+++ b/htdocs/api/v0.0.3-dev/projects/DataReleases.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Handles a request to the project's Data Releases export portion of the LORIS API
+ *
+ * PHP Version 7
+ *
+ * @category Main
+ * @package  API
+ * @author   Cécile Madjar <cecile.madjar2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+namespace Loris\API\Projects;
+//Load config file and ensure paths are correct
+set_include_path(get_include_path() . ":" . __DIR__ . "/../");
+
+require_once 'APIBase.php';
+
+/**
+ * Class to handle project's Data Release export portion of the LORIS API
+ *
+ * @category Main
+ * @package  API
+ * @author   Cécile Madjar <cecile.madjar2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class DataReleases extends \Loris\API\APIBase
+{
+    var $RequestData;
+    private $_project;
+
+    /**
+     * Create a Data Release request handler
+     *
+     * @param string $method      The HTTP request method of the request
+     * @param string $projectName The data that was POSTed to the request
+     */
+    public function __construct($method, $projectName)
+    {
+
+        $this->AllowedMethods = array('GET');
+        $this->AutoHandleRequestDelegation = false;
+
+        parent::__construct($method);
+
+        try {
+            $this->_project = $this->Factory->project($projectName);
+        } catch (\LorisException $e) {
+            $this->header("HTTP/1.1 404 Not Found");
+            $this->error(['error' => 'Invalid project']);
+            $this->safeExit(0);
+        }
+
+        try {
+            $dateString = $data['since'] ?? '1970-01-01';
+            $this->RequestData['since'] = new \DateTime($dateString);
+        } catch(\Exception $e) {
+            $this->header("HTTP/1.1 400 Bad Request");
+            $this->error(['error' => 'Invalid date']);
+            $this->safeExit(0);
+        }
+
+        $this->handleRequest();
+
+    }
+
+    /**
+     * Calculate an ETag by taking a hash of the number of Data Release files in the
+     * database and the time of the most recently changed one.
+     *
+     * @return string An ETag for ths candidates object
+     */
+    function calculateETag()
+    {
+        return md5('Releases:' . json_encode($this->JSON, true));
+    }
+
+    /**
+     * Handles a bids GET request
+     *
+     * @return void but populates $this->JSON
+     */
+    public function handleGET()
+    {
+        $data_release_versions = $this->DB->pselect(
+            "SELECT DISTINCT(version) FROM data_release",
+            array()
+        );
+
+        $data_release_arr = array();
+
+        foreach ($data_release_versions as $row) {
+            $version    = $row['version'];
+            $files_list = $this->DB->pselect(
+                "SELECT file_name FROM data_release WHERE version = :version",
+                array('version' => $version)
+            );
+            $files_path_list = array_map(
+                function ($item) {
+                    return array(
+                        'File' => $item,
+                        'Link' => 'data_releases/' . $item['file_name'],
+                    );
+                },
+                $files_list
+            );
+            array_push(
+                $data_release_arr,
+                array(
+                    'Data_Release_Version' => $version,
+                    'Files'                => $files_path_list,
+                )
+            );
+        }
+
+        $this->JSON = $data_release_arr;
+    }
+}
+
+if (isset($_REQUEST['PrintFiles'])) {
+    $obj = new DataReleases(
+        $_SERVER['REQUEST_METHOD'],
+        $_REQUEST['project_name']
+    );
+    print $obj->toJSONString();
+}

--- a/htdocs/api/v0.0.3-dev/projects/datareleases/DataReleaseFile.php
+++ b/htdocs/api/v0.0.3-dev/projects/datareleases/DataReleaseFile.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Handles API requests for the data release file download
+ *
+ * PHP Version 5.5+
+ *
+ * @category Main
+ * @package  API
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+namespace Loris\API\Projects\DataReleases;
+set_include_path(get_include_path() . ":" . __DIR__ . "/../");
+require_once __DIR__ . '/../DataReleases.php';
+/**
+ * Handles API requests for the data release file download.
+ *
+ * @category Main
+ * @package  API
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class DataReleaseFile extends \Loris\API\Projects\DataReleases
+{
+    var $RequestData;
+    private $_project;
+
+    /**
+     * @param string $method      The method of the HTTP request
+     * @param string $projectName The name of the project
+     * @param string $Filename    The file name to be retrieved
+     */
+    public function __construct($method, $projectName, $Filename)
+    {
+        $requestDelegationCascade = $this->AutoHandleRequestDelegation;
+
+        $this->AutoHandleRequestDelegation = false;
+
+        if (empty($this->AllowedMethods)) {
+            $this->AllowedMethods = ['GET', 'HEAD'];
+        }
+        $this->Filename = $Filename;
+
+        parent::__construct($method, $projectName);
+
+        $results = $this->getDatabaseDir();
+        if (true) {
+            $this->header("HTTP/1.1 404 Not Found");
+            $this->error("File not found");
+            $this->safeExit(0);
+        }
+
+        if ($requestDelegationCascade) {
+            $this->handleRequest();
+        }
+
+    }
+
+    /**
+     * Handles a GET request
+     *
+     * @return void but populates $this->JSON
+     */
+    public function handleGET()
+    {
+        $fullDir = $this->getFullPath();
+        ob_end_clean();
+
+        $fp = fopen($fullDir, "r");
+        if ($fp === false) {
+            $this->header("HTTP/1.1 500 Internal Server Error");
+            error_log("Could not open $fullDir to send to client");
+            $this->safeExit(1);
+        }
+
+        $this->Header('Cache-control: private');
+
+        if (pathinfo($fullDir)['extension'] == 'csv') {
+            $contentType = 'text/csv';
+        } else {
+            $contentType = 'text/plain';
+        }
+        $this->Header("Content-Type: $contentType");
+        $this->Header('Content-Length: ' . filesize($fullDir));
+        $this->Header('Content-Disposition: attachment; filename=' . basename($this->Filename));
+
+        fpassthru($fp);
+        fclose($fp);
+        $this->safeExit(0);
+    }
+
+    /**
+     * Gets the full path of this image on the filesystem, in order
+     * to be able to pass it to an fopen command (or similar)
+     *
+     * @return string
+     */
+    protected function getFullPath()
+    {
+        return $this->getDataReleaseDir() . "/" . $this->getDatabaseDir();
+    }
+
+    /**
+     * Gets the root of the base directory of the LORIS code, so that we know where
+     * to retrieve images relative to.
+     *
+     * @return string
+     */
+    protected function getDataReleaseDir()
+    {
+        $factory = \NDB_Factory::singleton();
+        $config  = $factory->Config();
+        return $config->getSetting("base") . '/project/modules/data_release/user_uploads/';
+    }
+
+    /**
+     * Gets the filename saved in the database for this file
+     *
+     * @return string
+     */
+    protected function getDatabaseDir()
+    {
+        $factory = \NDB_Factory::singleton();
+        $db      = $factory->Database();
+        return $db->pselectOne(
+            "SELECT file_name
+                FROM data_release
+                WHERE file_name LIKE CONCAT('%', :Fname)",
+            array(
+                'Fname' => $this->Filename,
+            )
+        );
+    }
+
+}
+
+if (isset($_REQUEST['PrintFileData'])) {
+    $obj = new DataReleaseFile(
+        $_SERVER['REQUEST_METHOD'],
+        $_REQUEST['project_name'],
+        $_REQUEST['Filename']
+    );
+    print $obj->toJSONString();
+}


### PR DESCRIPTION
## Brief summary of changes

This adds endpoints to the API so that the data release files can be downloaded via the API.

Endpoints:
- api/v0.0.3-dev/projects/loris/data_releases => returns the list of files per data release versions
- api/v0.0.3-dev/projects/loris/data_releases/<FileName> => will download the file the user wants
